### PR TITLE
Adjust CircleCI config to support caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,21 +5,21 @@ version: 2.1
 # See: https://circleci.com/docs/2.0/orb-intro/
 orbs:
     node: circleci/node@5.0.0
-    cypress: cypress-io/cypress@1.29.0
     codecov: codecov/codecov@3.2.2
+    cypress: samuelboland/cypress@0.0.12
 
 # Invoke jobs via workflows
 # See: https://circleci.com/docs/2.0/configuration-reference/#workflows
 
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Jobs ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Jobs ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Executors for Cypress ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #
 
 # List of executors can be found here: https://github.com/cypress-io/cypress-docker-images/tree/master/browsers
 executors:
-  with-chrome:
-    docker:
-      - image: 'cypress/browsers:node16.5.0-chrome97-ff96'
+    with-chrome:
+        docker:
+            - image: 'cypress/browsers:node16.5.0-chrome97-ff96'
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Workflows ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #
 workflows:
@@ -34,21 +34,19 @@ workflows:
                             path: coverage
                       - codecov/upload
             - cypress/install:
-                build: npm run build
+                  build: npm run build
+                  cache-key: cache-{{ checksum "package.json"}}
             - cypress/run:
-                store_artifacts: true
-                executor: with-chrome
-                browser: chrome
-                requires: 
-                    - cypress/install
-                        
-                attach-workspace: true
-                start: npm run start
-                wait-on: 
-                    "http-get://localhost:3000"
-                post-steps: 
-                    - store_artifacts: 
-                          path: coverage
-                    - codecov/upload
-
-                
+                  cache-key: cache-{{ checksum "package.json"}}
+                  store_artifacts: true
+                  executor: with-chrome
+                  browser: chrome
+                  requires:
+                      - cypress/install
+                  attach-workspace: true
+                  start: npm run start
+                  wait-on: 'http-get://localhost:3000'
+                  post-steps:
+                      - store_artifacts:
+                            path: coverage
+                      - codecov/upload

--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@
 /cypress/screenshots
 
 # next.js
-/.next/
+/.next/*
 /out/
 
 # production


### PR DESCRIPTION
Added an optional cache key to specify how the cache should be named.
Cypress was using a very restrictive naming scheme that resulted in
cache misses the majority of the time.

I have also adjusted the orb itself. I forked it and uploaded my own
version to CircleCI. In that version, I move the cache step to after
the build step, and also cache the `.next/cache` folder, which speeds
up future builds where that cache is valid.

I intend to bring much of the functionality of the orb into my own
CircleCI config so that I don't have to rely on a hacky personal version
for basic functionality.

Solves #17 